### PR TITLE
nbdkit: Use cacheextents if possible for vddk input

### DIFF
--- a/v2v/nbdkit.ml
+++ b/v2v/nbdkit.ml
@@ -169,6 +169,13 @@ let common_create ?bandwidth plugin_name plugin_args plugin_env =
     )
     else [] in
 
+  (* Caching extents speeds up qemu-img, especially its consecutive
+     block_status requests with req_one=1.
+  *)
+  if probe_filter "cacheextents" then (
+    add_arg "--filter"; add_arg "cacheextents"
+  );
+
   (* Retry filter (if it exists) can be used to get around brief
    * interruptions in service.  It must be closest to the plugin.
    *)


### PR DESCRIPTION
It does not need configuring and speeds up the process of requesting extents if
the client asks for them one by one (like qemu-img).

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>