### PR TITLE
libosinfo: declare autocleanup funcs with libosinfo < 1.8.0

### DIFF
--- a/v2v/libosinfo-c.c
+++ b/v2v/libosinfo-c.c
@@ -40,8 +40,13 @@
 #define V2V_LIBOSINFO_VERSION_HEX \
     MAKE_VERSION_HEX(OSINFO_MAJOR_VERSION, OSINFO_MINOR_VERSION, OSINFO_MICRO_VERSION)
 #define IS_LIBOSINFO_VERSION(maj, min, mic) \
-    V2V_LIBOSINFO_VERSION_HEX >= MAKE_VERSION_HEX(maj, min, mic)
+    (V2V_LIBOSINFO_VERSION_HEX >= MAKE_VERSION_HEX(maj, min, mic))
 
+/*
+ * libosinfo 1.8.0 provides auto-cleanup functions for all its classes,
+ * so avoid declaring our own.
+ */
+#if !IS_LIBOSINFO_VERSION(1, 8, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OsinfoFilter, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OsinfoLoader, g_object_unref)
 /*
@@ -50,11 +55,13 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(OsinfoLoader, g_object_unref)
  * avoid declaring this when:
  * - libosinfo is >= 1.7.0 and < 1.8.0
  * - glib is >= 2.63.3
+ * (the 1.8.0 check is not done, as already covered by the check above)
  */
-#if !IS_LIBOSINFO_VERSION(1, 7, 0) || IS_LIBOSINFO_VERSION(1, 8, 0) || !GLIB_CHECK_VERSION(2, 63, 3)
+#if !IS_LIBOSINFO_VERSION(1, 7, 0) || !GLIB_CHECK_VERSION(2, 63, 3)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OsinfoList, g_object_unref)
 #endif
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(OsinfoOsList, g_object_unref)
+#endif
 
 typedef OsinfoDb *OsinfoDb_t;
 typedef OsinfoOs *OsinfoOs_t;


### PR DESCRIPTION
libosinfo 1.8.0 declares them automatically for all of its classes, so
there is no need to declare ours. This requires fixing the definition of
the IS_LIBOSINFO_VERSION macro to wrap its body in brackets.

While in the process, simplify the workaround for a related bug by
removing a now-useless check.