### PR TITLE
libvirt: read password file outside libvirt auth callback

### DIFF
--- a/v2v/libvirt_utils.ml
+++ b/v2v/libvirt_utils.ml
@@ -24,8 +24,8 @@ open Common_gettext.Gettext
     module. *)
 
 let auth_for_password_file ?password_file () =
+  let password = Option.map read_first_line_from_file password_file in
   let auth_fn creds =
-    let password = Option.map read_first_line_from_file password_file in
     List.map (
       function
       | { Libvirt.Connect.typ = Libvirt.Connect.CredentialPassphrase } -> password


### PR DESCRIPTION
This way errors that occur while reading the password file are properly
propagated, instead of being reported as errors of the libvirt
authentication callback.

Reported by: Ming Xie.