### PR TITLE
v2v: Use correct value "i386" rather than bogus value for 32 bit x86.

### DIFF
--- a/v2v/convert_linux.ml
+++ b/v2v/convert_linux.ml
@@ -1117,7 +1117,7 @@ let convert (g : G.guestfs) inspect source_disks output rcaps _ =
 
       let get_uefi_arch_suffix = function
         | "x86_64" -> Some "X64"
-        | "x86_32" -> Some "X32"
+        | "i386" -> Some "X32"
         | _ -> None
       in
 


### PR DESCRIPTION
Fixes: commit 59f0c279526306e56a6f971ac3d52e3276b1bdd3
Thanks Sam Eiderman